### PR TITLE
feat: integrate Lenco subscription payments

### DIFF
--- a/erpnext/erpnext_integrations/lenco_subscription.py
+++ b/erpnext/erpnext_integrations/lenco_subscription.py
@@ -1,0 +1,81 @@
+import os
+from datetime import datetime, timedelta
+from dataclasses import dataclass
+import requests
+
+# Lenco API configuration
+LENCO_BASE_URL = os.environ.get("LENCO_BASE_URL", "https://api.lenco.co/access/v2")
+LENCO_SECRET_KEY = os.environ.get("LENCO_SECRET_KEY", "725867721a5e2717b4619606b04465cad02788915a90963d03fabb5dbc3757b9")
+LENCO_PUBLIC_KEY = os.environ.get("LENCO_PUBLIC_KEY", "pub-f3d19a14ad9bd820fc5c0239dd6957fb14b0223bd6d15525")
+LENCO_WEBHOOK_SIGNATURE_KEY = os.environ.get(
+    "LENCO_WEBHOOK_SIGNATURE_KEY",
+    "7133d6bce4299a56439089294785c0624dca56b6c77159237020503ce77589e8",
+)
+
+
+@dataclass
+class LencoSubscription:
+    """Handle subscription payments via Lenco."""
+
+    plan: str
+    user_count: int = 1
+
+    BASE_PLAN_PRICES = {
+        "monthly": 2500,
+        "quarterly": 7000,
+        "yearly": 35000,
+    }
+    USERS_INCLUDED = 3
+    EXTRA_USER_PRICE = 1500
+    ALLOWED_METHODS = {"mobile_money", "bank_transfer", "card"}
+
+    def amount(self) -> int:
+        base = self.BASE_PLAN_PRICES[self.plan]
+        extra_users = max(0, self.user_count - self.USERS_INCLUDED)
+        return base + extra_users * self.EXTRA_USER_PRICE
+
+    def create_payment(self, payment_method: str, customer_name: str) -> dict:
+        """Create a payment session on Lenco."""
+        if payment_method not in self.ALLOWED_METHODS:
+            raise ValueError("Unsupported payment method")
+        payload = {
+            "amount": self.amount(),
+            "currency": "ZMW",
+            "payment_method": payment_method,
+            "customer_name": customer_name,
+        }
+        headers = {"Authorization": f"Bearer {LENCO_SECRET_KEY}"}
+        response = requests.post(
+            f"{LENCO_BASE_URL}/payments", json=payload, headers=headers, timeout=10
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def verify_payment(self, payment_id: str) -> dict:
+        """Verify payment status before enabling subscription."""
+        headers = {"Authorization": f"Bearer {LENCO_SECRET_KEY}"}
+        response = requests.get(
+            f"{LENCO_BASE_URL}/payments/{payment_id}", headers=headers, timeout=10
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+class TrialTracker:
+    """Track trial usage limited by days or number of transactions."""
+
+    MAX_DAYS = 10
+    MAX_TRANSACTIONS = 50
+
+    def __init__(self, start: datetime | None = None, transaction_count: int = 0):
+        self.start = start or datetime.utcnow()
+        self.transaction_count = transaction_count
+
+    def record_transaction(self) -> None:
+        self.transaction_count += 1
+
+    @property
+    def expired(self) -> bool:
+        if datetime.utcnow() - self.start >= timedelta(days=self.MAX_DAYS):
+            return True
+        return self.transaction_count >= self.MAX_TRANSACTIONS

--- a/tests/test_lenco_subscription.py
+++ b/tests/test_lenco_subscription.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timedelta
+import importlib.util
+import pathlib
+
+module_path = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "erpnext"
+    / "erpnext_integrations"
+    / "lenco_subscription.py"
+)
+spec = importlib.util.spec_from_file_location("lenco_subscription", module_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+LencoSubscription = module.LencoSubscription
+TrialTracker = module.TrialTracker
+
+
+def test_amount_within_included_users():
+    sub = LencoSubscription("monthly", user_count=3)
+    assert sub.amount() == 2500
+
+
+def test_amount_extra_users():
+    sub = LencoSubscription("quarterly", user_count=5)
+    assert sub.amount() == 7000 + 2 * 1500
+
+
+def test_trial_expires_by_days():
+    tracker = TrialTracker(start=datetime.utcnow() - timedelta(days=11))
+    assert tracker.expired
+
+
+def test_trial_expires_by_transactions():
+    tracker = TrialTracker(transaction_count=50)
+    assert tracker.expired


### PR DESCRIPTION
## Summary
- add Lenco subscription client with pricing rules and trial tracking
- restrict payments to mobile money, bank transfer or card
- verify payments via Lenco API

## Testing
- `pytest tests/test_lenco_subscription.py`


------
https://chatgpt.com/codex/tasks/task_e_68aed89c7cc0832891e1e0a51dd14f96